### PR TITLE
report ファイルアップロード後のウェブフックに recording_metadata を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] report ファイルアップロード後のウェブフックに `recording_metadata` を追加する
+  - アップロードした report ファイルの `recording_metadata` の内容をウェブフックに含めて送信する
+  - @tnamao
 - [UPDATE] CI の staticcheck を 2024.1.1 にアップデート
   - @voluntas
 - [UPDATE] go 1.23.2 にアップデート

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,11 @@
 ## develop
 
 - [UPDATE] report ファイルアップロード後のウェブフックに `recording_metadata` を追加する
-  - アップロードした report ファイルの `recording_metadata` の内容をウェブフックに含めて送信する
-  - report ファイルに `recording_metadata` のキーが存在しない場合にはウェブフックにも `recording_metadata` を含めない
+  - アップロードした report ファイルの `recording_metadata` または `metadata` の内容をウェブフックの `recording_metadata` に含めて送信する
+    - セッション録画の場合は `recording_metadata` の値を使用する
+    - レガシー録画の場合は `metadata` の値を使用する
+    - ウェブフックに含める際のキーはセッション録画でもレガシー録画でも共通で `recording_metadata` に設定する
+  - report ファイルに `recording_metadata` または `metadata` のキーが存在しない場合にはウェブフックにも `recording_metadata` を含めない
   - @tnamao
 - [UPDATE] CI の staticcheck を 2024.1.1 にアップデート
   - @voluntas

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - [UPDATE] report ファイルアップロード後のウェブフックに `recording_metadata` を追加する
   - アップロードした report ファイルの `recording_metadata` の内容をウェブフックに含めて送信する
+  - report ファイルに `recording_metadata` のキーが存在しない場合にはウェブフックにも `recording_metadata` を含めない
   - @tnamao
 - [UPDATE] CI の staticcheck を 2024.1.1 にアップデート
   - @voluntas

--- a/uploader.go
+++ b/uploader.go
@@ -17,10 +17,11 @@ import (
 )
 
 type RecordingReport struct {
-	RecordingID string `json:"recording_id"`
-	ChannelID   string `json:"channel_id"`
-	FilePath    string `json:"file_path"`
-	Filename    string `json:"filename"`
+	RecordingID       string          `json:"recording_id"`
+	ChannelID         string          `json:"channel_id"`
+	FilePath          string          `json:"file_path"`
+	Filename          string          `json:"filename"`
+	RecordingMetadata json.RawMessage `json:"recording_metadata"`
 }
 
 type UploaderManager struct {
@@ -459,13 +460,14 @@ func (u Uploader) handleReport(reportJSONFilePath string) bool {
 			return false
 		}
 		var w = WebhookReportUploaded{
-			ID:          webhookID,
-			Type:        u.config.WebhookTypeReportUploaded,
-			Timestamp:   time.Now().UTC(),
-			RecordingID: rr.RecordingID,
-			ChannelID:   rr.ChannelID,
-			Filename:    filename,
-			FileURL:     fileURL,
+			ID:                webhookID,
+			Type:              u.config.WebhookTypeReportUploaded,
+			Timestamp:         time.Now().UTC(),
+			RecordingID:       rr.RecordingID,
+			ChannelID:         rr.ChannelID,
+			Filename:          filename,
+			FileURL:           fileURL,
+			RecordingMetadata: rr.RecordingMetadata,
 		}
 		buf, err := json.Marshal(w)
 		if err != nil {

--- a/webhook.go
+++ b/webhook.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,13 +13,14 @@ import (
 )
 
 type WebhookReportUploaded struct {
-	ID          string    `json:"id"`
-	Type        string    `json:"type"`
-	Timestamp   time.Time `json:"timestamp"`
-	RecordingID string    `json:"recording_id"`
-	ChannelID   string    `json:"channel_id"`
-	Filename    string    `json:"filename"`
-	FileURL     string    `json:"file_url"`
+	ID                string          `json:"id"`
+	Type              string          `json:"type"`
+	Timestamp         time.Time       `json:"timestamp"`
+	RecordingID       string          `json:"recording_id"`
+	ChannelID         string          `json:"channel_id"`
+	Filename          string          `json:"filename"`
+	FileURL           string          `json:"file_url"`
+	RecordingMetadata json.RawMessage `json:"recording_metadata,omitempty"`
 }
 
 type WebhookArchiveUploaded struct {


### PR DESCRIPTION
### 変更履歴

- [UPDATE] report ファイルアップロード後のウェブフックに `recording_metadata` を追加する
  - アップロードした report ファイルの `recording_metadata` または `metadata` の内容をウェブフックの `recording_metadata` に含めて送信する
    - セッション録画の場合は `recording_metadata` の値を使用する
    - レガシー録画の場合は `metadata` の値を使用する
    - ウェブフックに含める際のキーはセッション録画でもレガシー録画でも共通で `recording_metadata` に設定する
  - report ファイルに `recording_metadata` または `metadata` のキーが存在しない場合にはウェブフックにも `recording_metadata` を含めない
  - @tnamao

---

This pull request includes several updates to enhance the handling of recording metadata and improve the webhook functionality. The most important changes include adding new fields to the `RecordingReport` and `WebhookReportUploaded` structures, updating the webhook logic to handle different types of recordings, and making necessary imports for JSON handling.

### Enhancements to recording metadata handling:

* [`uploader.go`](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8R22-R26): Added `SessionID`, `Metadata`, and `RecordingMetadata` fields to the `RecordingReport` structure to support different types of recording metadata.
* [`uploader.go`](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8R473-R481): Updated the `handleReport` function to differentiate between session recordings and legacy recordings based on the `SessionID` field and set the `RecordingMetadata` accordingly.

### Webhook improvements:

* [`webhook.go`](diffhunk://#diff-6d78887239bedc3eed05d1bd7618446de929a592a8bb2b686d86dcfccb4b869dR23): Added `RecordingMetadata` field to the `WebhookReportUploaded` structure to include recording metadata in the webhook payload.

### Additional updates:

* [`webhook.go`](diffhunk://#diff-6d78887239bedc3eed05d1bd7618446de929a592a8bb2b686d86dcfccb4b869dR7): Added the `encoding/json` import to handle JSON operations required for the new fields.

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20): Documented the addition of `recording_metadata` to the webhook after file upload, including details on handling session and legacy recordings.