### PR TITLE
mp4 ファイル対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] アップロードする録画データのファイルを `.webm` だけではなく `.mp4` のスクレイピングにも対応する
+  - ログのメッセージや出力する際のパラメータ名、プログラム中の変数名や関数名も webm を使用している箇所は media に変更する
+  - @tnamao
 - [UPDATE] 設定に `exclude_webhook_recording_metadata` を追加し、report ファイルアップロード後のウェブフックに `recording_metadata` を含めるかどうか設定できるようにする
   - デフォルトは `false` で `recording_metadata` を送信するウェブフックに含める
   - `true` を設定するとレポートファイルに `recording_metadata` または `metadata` が含まれていてもウェブフックには含めない

--- a/s3.go
+++ b/s3.go
@@ -86,7 +86,7 @@ func uploadMediaFile(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage
 
 	zlog.Info().
 		Str("dst", dst).
-		Msg("WEB-UPLOAD-START")
+		Msg("MEDIA-FILE-UPLOAD-START")
 	n, err := s3Client.FPutObject(ctx,
 		osConfig.BucketName, dst, filePath,
 		minio.PutObjectOptions{ContentType: "application/octet-stream"},

--- a/s3.go
+++ b/s3.go
@@ -66,7 +66,7 @@ func uploadJSONFile(
 	return objectURL, nil
 }
 
-func uploadWebMFile(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage, dst, filePath string) (string, error) {
+func uploadMediaFile(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage, dst, filePath string) (string, error) {
 	var creds *credentials.Credentials
 	if (osConfig.AccessKeyID != "") || (osConfig.SecretAccessKey != "") {
 		creds = credentials.NewStaticV4(
@@ -97,7 +97,7 @@ func uploadWebMFile(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage,
 	zlog.Info().
 		Str("dst", dst).
 		Int64("size", n.Size).
-		Msg("UPLOAD-WEBM-SUCCESSFULLY")
+		Msg("UPLOAD-MEDIA-FILE-SUCCESSFULLY")
 
 	reqParams := make(url.Values)
 	filename := filepath.Base(dst)
@@ -127,7 +127,7 @@ func isFileContinuous(err error) bool {
 	return true
 }
 
-func uploadWebMFileWithRateLimit(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage, dst, filePath string,
+func uploadMediaFileWithRateLimit(ctx context.Context, osConfig *s3.S3CompatibleObjectStorage, dst, filePath string,
 	rateLimitMpbs int) (string, error) {
 	var creds *credentials.Credentials
 	if (osConfig.AccessKeyID != "") || (osConfig.SecretAccessKey != "") {
@@ -179,7 +179,7 @@ func uploadWebMFileWithRateLimit(ctx context.Context, osConfig *s3.S3CompatibleO
 
 	zlog.Info().
 		Str("dst", dst).
-		Msg("WEB-UPLOAD-START")
+		Msg("MEDIA-FILE-UPLOAD-START")
 
 	// 使用帯域の制限時は、巨大なサイズのファイルのアップロードする時に使用される multipart アップロードで
 	// 並列アップロードは行わずに 1 thread で処理されるようにオプションを設定する
@@ -192,7 +192,7 @@ func uploadWebMFileWithRateLimit(ctx context.Context, osConfig *s3.S3CompatibleO
 	zlog.Info().
 		Str("dst", dst).
 		Int64("size", n.Size).
-		Msg("UPLOAD-WEBM-SUCCESSFULLY")
+		Msg("UPLOAD-MEDIA-FILE-SUCCESSFULLY")
 
 	objectURL := fmt.Sprintf("s3://%s/%s", n.Bucket, n.Key)
 	return objectURL, nil


### PR DESCRIPTION
### 変更履歴

- [CHANGE] アップロードする録画データのファイルを `.webm` だけではなく `.mp4` のスクレイピングにも対応する
  - ログのメッセージや出力する際のパラメータ名、プログラム中の変数名や関数名も webm を使用している箇所は media に変更する
  - @tnamao

---

This pull request introduces support for handling `.mp4` files in addition to `.webm` files for scraping and uploading recorded media data. It also standardizes terminology by replacing "webm" with "media" across variable names, function names, and log messages to accommodate the broader file type support.

### Support for `.mp4` files:
* Updated the file scraping logic in `finder.go` to check for both `.webm` and `.mp4` files, ensuring that either file type can be passed to subsequent processes. (`[finder.goL53-R73](diffhunk://#diff-b46603bb7e7e15a943ef4a0c326e4e9f23a1833a414fb9f0fbc922ef836365dbL53-R73)`)
* Adjusted the file replacement pattern from `replaceWebmPattern` to `replaceFilenamePattern` for generality. (`[finder.goL20-R20](diffhunk://#diff-b46603bb7e7e15a943ef4a0c326e4e9f23a1833a414fb9f0fbc922ef836365dbL20-R20)`)

### Terminology standardization:
* Renamed functions and variables in `s3.go` from "WebM" to "Media" to reflect support for multiple media types (e.g., `uploadWebMFile` → `uploadMediaFile`). (`[[1]](diffhunk://#diff-b6f449e81d2d5b668ab781e2914e738bfc85066a4ea3cd0d999c06b40fdfc691L69-R69)`, `[[2]](diffhunk://#diff-b6f449e81d2d5b668ab781e2914e738bfc85066a4ea3cd0d999c06b40fdfc691L130-R130)`)
* Updated log messages in `s3.go` and `uploader.go` to use "MEDIA" instead of "WEBM" for consistency. (`[[1]](diffhunk://#diff-b6f449e81d2d5b668ab781e2914e738bfc85066a4ea3cd0d999c06b40fdfc691L89-R89)`, `[[2]](diffhunk://#diff-b6f449e81d2d5b668ab781e2914e738bfc85066a4ea3cd0d999c06b40fdfc691L100-R100)`, `[[3]](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8L258-R273)`)

### File handling adjustments:
* Replaced `.webm`-specific logic in `uploader.go` with generalized handling for media files, including changes to file paths, object keys, and removal methods. (`[[1]](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8L244-R246)`, `[[2]](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8L649-R680)`)
* Introduced new methods like `removeArchiveMediaFile` to replace `.webm`-specific counterparts. (`[uploader.goL649-R680](diffhunk://#diff-c11a041cee1ec876884b94e5c75d92eeb5ffc125353739d396a2d30265b9e5f8L649-R680)`)

### Documentation updates:
* Updated `CHANGES.md` to document the new `.mp4` support and the associated changes in variable and parameter naming. (`[CHANGES.mdR14-R16](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16)`)